### PR TITLE
Add debug information for failed api calls

### DIFF
--- a/gh-copilot-review
+++ b/gh-copilot-review
@@ -94,7 +94,12 @@ if [ $status -eq 0 ]; then
   echo "✅ Success: Requested Copilot Code Review on https://github.com/${repo}/pull/${pr_number}"
 else
   echo "❌ Failure: Could not request Copilot Code Review on https://github.com/${repo}/pull/${pr_number}"
-  echo "Debug Info:"
-  echo "$response"
+
+  # Only show debug info if DEBUG_COPILOT_REVIEW is set
+  if [ "${DEBUG_COPILOT_REVIEW:-}" = "true" ]; then
+    echo "🔍 Debug Info:"
+    echo "$response" | jq . || echo "$response"
+  fi
+
   exit $status
 fi

--- a/gh-copilot-review
+++ b/gh-copilot-review
@@ -83,13 +83,18 @@ case "$input" in
     ;;
 esac
 
-echo "🔍 Requesting Copilot Code Review on ${repo} PR #${pr_number}..."
-
 # Make the API call
-if gh api --method POST "/repos/${repo}/pulls/${pr_number}/requested_reviewers" \
-  -f "reviewers[]=copilot-pull-request-reviewer[bot]" >/dev/null 2>&1; then
+echo "🔍 Requesting Copilot Code Review on ${repo} PR #${pr_number}..."
+response=$(gh api --method POST "/repos/${repo}/pulls/${pr_number}/requested_reviewers" \
+  -f "reviewers[]=copilot-pull-request-reviewer[bot]" 2>&1)
+status=$?
+
+# Validate response
+if [ $status -eq 0 ]; then
   echo "✅ Success: Requested Copilot Code Review on https://github.com/${repo}/pull/${pr_number}"
 else
   echo "❌ Failure: Could not request Copilot Code Review on https://github.com/${repo}/pull/${pr_number}"
-  exit 1
+  echo "Debug Info:"
+  echo "$response"
+  exit $status
 fi


### PR DESCRIPTION
Add debug information when there is an error hitting the api. 

We only debug if  the environment variable DEBUG_COPILOT_REVIEW is set. 